### PR TITLE
Feature/add config file multihost

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,30 @@ This is a BRASH plugin for cFE that is based on using Juicer to generate message
 
 ### Using the cFE ROS2 bridge ###
 
-* TODO
+To run:
+
+```
+ros2 launch cfe_plugin cfe_bridge.launch.py
+```
+
+This launch file accepts as argument **cfe_config** . This file contains 
+configuration information for the bridge. Most of the parameters can be used
+with its default values. You'll only want to modify the parameters that 
+define the location of your gsw machine, specifically:
+
+- udp_command_ip
+- udp_send_port
+
+
+Currently, we have available 2 configuration files to use, both
+located in cfe_sbn_plugin/config:
+
+- cfe_config.yaml: File applicable for a single-host setup. This is the default.
+- cfe_config_multihost.yaml:  File applicable for a multihost setup, such as the one used by brash docker.
+
+You can create your own file using these files as reference.
 
 ### Who do I talk to? ###
 
-* Repo owner or admin
-* Other community or team contact
+* Contact: brash@traclabs.com
+

--- a/cfe_plugin/cfe_plugin/cfe_plugin.py
+++ b/cfe_plugin/cfe_plugin/cfe_plugin.py
@@ -90,12 +90,8 @@ class FSWPlugin(FSWPluginInterface):
         self._node.get_logger().info('udp_receive_port: ' + str(self._telemetry_port))
 
         self._node.declare_parameter('plugin_params.udp_send_port', 1234)
-        self._command_port = os.environ.get("FSW_CMD_PORT")
-        if not self._command_port:
-            self._command_port = self._node.get_parameter('plugin_params.udp_send_port'). \
+        self._command_port = self._node.get_parameter('plugin_params.udp_send_port'). \
                 get_parameter_value().integer_value
-        else:
-            self._command_port = int(self._command_port)
         self._node.get_logger().info('udp_send_port: ' + str(self._command_port))
 
         # Bind address
@@ -106,9 +102,7 @@ class FSWPlugin(FSWPluginInterface):
 
         # Transmit Address
         self._node.declare_parameter('plugin_params.udp_command_ip', '127.0.0.1')
-        self._command_ip = os.environ.get("FSW_IP")
-        if not self._command_ip:
-            self._command_ip = self._node.get_parameter('plugin_params.udp_command_ip'). \
+        self._command_ip = self._node.get_parameter('plugin_params.udp_command_ip'). \
                 get_parameter_value().string_value
         self._node.get_logger().info('udp_command_ip: ' + str(self._command_ip))
 

--- a/cfe_plugin/config/cfe_config_multihost.yaml
+++ b/cfe_plugin/config/cfe_config_multihost.yaml
@@ -1,0 +1,9 @@
+cfe_bridge:
+  ros__parameters:
+    plugin_name: cfe_plugin.cfe_plugin
+    namespace: /groundsystem
+    plugin_params:
+      udp_telemetry_ip: "0.0.0.0"
+      udp_command_ip: "10.5.0.3" # IP for fsw machine. 127.0.0.1 for singlehost setup, 10.5.0.3 for multihost setup 
+      udp_receive_port: 1235
+      udp_send_port: 1235       # 1234 for cpu1 (singlehost setup), 1235 for cpu2 (multihost setup)

--- a/cfe_plugin/launch/cfe_bridge.launch.py
+++ b/cfe_plugin/launch/cfe_bridge.launch.py
@@ -2,21 +2,29 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
-
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
 def generate_launch_description():
-    ld = LaunchDescription()
-    config = os.path.join(
+    
+    # Argument to set cfe_config file to use, dependent on your specific setup
+    # default: cfe_config.yaml is good for single-host setups 
+    # alternative: cfe_config_multihost.yaml is good for multihost setups, such as the docker demo 
+    cfe_config = LaunchConfiguration('cfe_config')
+    cfe_config_launch_arg = DeclareLaunchArgument('cfe_config', default_value='cfe_config.yaml',
+                            description='cfe_config yaml file')
+        
+    config = PathJoinSubstitution([
         get_package_share_directory('cfe_plugin'),
         'config',
-        'cfe_config.yaml'
-        )
+        cfe_config
+        ])
 
-    juicer_config = os.path.join(
+    juicer_config = PathJoinSubstitution([
         get_package_share_directory('juicer_util'),
         'config',
         'cfe_plugin_config.yaml'
-        )
+        ])
 
     node = Node(
         package='fsw_ros2_bridge',
@@ -24,5 +32,9 @@ def generate_launch_description():
         executable='fsw_ros2_bridge',
         parameters=[config, juicer_config]
     )
-    ld.add_action(node)
-    return ld
+
+    return LaunchDescription([
+      cfe_config_launch_arg,
+      node
+    ])
+


### PR DESCRIPTION
This PR does a couple of things:

1. Delete **os.get_environ()** from cfe_ros2_plugin.py . The parameters that the bridge reads are now only read from the configuration yaml file.
2. Update the **launch file for cfe_ros2_plugin** such that the user can set an argument for **cfe_config** . This way, a user can create a yaml specific for his setup (e.g. multihost, singlehost) and use this yaml when launching the bridge.
3. Added a new yaml file (**cfe_config_multihost.yaml**) that corresponds to the Docker setup.
4. Default config file is still the **cfe_config.yaml** file, which is suitable for the singlehost setup of the earliest tutorials.

Tested in both the single-host and multihost setups, each using the configuration files accordingly. Works as expected.
