### PR TITLE
Add basic telemetry flow check between fsw and rosgsw

### DIFF
--- a/cfe_plugin/CMakeLists.txt
+++ b/cfe_plugin/CMakeLists.txt
@@ -40,4 +40,11 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_ros REQUIRED)
+  ament_add_pytest_test(
+    test_telemetry_flow test/test_telemetry_flow.py
+    TIMEOUT 90)
+endif()
+
 ament_package()

--- a/cfe_plugin/test/test_telemetry_flow.py
+++ b/cfe_plugin/test/test_telemetry_flow.py
@@ -1,0 +1,48 @@
+import unittest
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+
+from cfe_msgs.msg import CFEESHousekeepingTlm
+
+class TelemetryFlowSubscriber(Node):
+   def __init__(self):
+      super().__init__('telemetry_flow_subscriber')
+      self.subscription = self.create_subscription(
+         CFEESHousekeepingTlm,
+         '/groundsystem/cfe_es_hk_tlm',
+         self.listener_callback,
+         10)
+      self.subscription  # prevent unused variable warning
+      self.num_messages_received = 0
+
+   def listener_callback(self, msg):
+      self.num_messages_received += 1
+      self.get_logger().info('I heard something')
+
+   def get_messages_heard(self):
+      return self.num_messages_received
+
+class TestTelemetryFlow(unittest.TestCase):
+   @classmethod
+   def setUpClass(cls):
+      # Initialize the ROS context for the test node
+      rclpy.init()
+
+   @classmethod
+   def tearDownClass(cls):
+      # Shutdown the ROS context
+      rclpy.shutdown()
+
+   def test_flow(self):
+      subscriber = TelemetryFlowSubscriber()
+
+      rclpy.spin_once(subscriber, timeout_sec=30)
+
+      self.assertTrue(subscriber.get_messages_heard() > 0, "Didn't receive any subscribed messages.")
+
+      subscriber.destroy_node()
+
+if __name__ == '__main__':
+   unittest.main()


### PR DESCRIPTION
This is a PR to add a simple test verifying that ES HK TLM makes it down as a /groundsystem topic.

The test is run as part of:
```
colcon test  --event-handlers console_cohesion+ --ctest-args " -VVV" --return-code-on-test-failure --packages-select cfe_plugin
```
And the result looks like this:
```
    Start 1: test_telemetry_flow

1: Test command: /usr/bin/python3.10 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/code/brash/build/cfe_plugin/test_results/cfe_plugin/test_telemetry_flow.xunit.xml" "--package-name" "cfe_plugin" "--output-file" "/code/brash/build/cfe_plugin/ament_cmake_pytest/test_telemetry_flow.txt" "--command" "/usr/bin/python3.10" "-u" "-m" "pytest" "/code/brash/src/cfe_ros2_bridge_plugin/cfe_plugin/test/test_telemetry_flow.py" "-o" "cache_dir=/code/brash/build/cfe_plugin/ament_cmake_pytest/test_telemetry_flow/.cache" "--junit-xml=/code/brash/build/cfe_plugin/test_results/cfe_plugin/test_telemetry_flow.xunit.xml" "--junit-prefix=cfe_plugin"
1: Test timeout computed to be: 90
1: -- run_test.py: invoking following command in '/code/brash/build/cfe_plugin':
1:  - /usr/bin/python3.10 -u -m pytest /code/brash/src/cfe_ros2_bridge_plugin/cfe_plugin/test/test_telemetry_flow.py -o cache_dir=/code/brash/build/cfe_plugin/ament_cmake_pytest/test_telemetry_flow/.cache --junit-xml=/code/brash/build/cfe_plugin/test_results/cfe_plugin/test_telemetry_flow.xunit.xml --junit-prefix=cfe_plugin
1: ============================= test session starts ==============================
1: platform linux -- Python 3.10.12, pytest-6.2.5, py-1.10.0, pluggy-0.13.0
1: cachedir: /code/brash/build/cfe_plugin/ament_cmake_pytest/test_telemetry_flow/.cache
1: rootdir: /code/brash/src/cfe_ros2_bridge_plugin/cfe_plugin, configfile: pytest.ini
1: plugins: launch-testing-ros-0.19.7, ament-xmllint-0.12.10, ament-copyright-0.12.10, ament-lint-0.12.10, ament-pep257-0.12.10, launch-testing-1.0.4, ament-flake8-0.12.10, colcon-core-0.15.2
1: collected 1 item
1: 
1: ../../src/cfe_ros2_bridge_plugin/cfe_plugin/test/test_telemetry_flow.py . [100%]
1: 
1: - generated xml file: /code/brash/build/cfe_plugin/test_results/cfe_plugin/test_telemetry_flow.xunit.xml -
1: ============================== 1 passed in 1.40s ===============================
1: -- run_test.py: return code 0
1: -- run_test.py: verify result file '/code/brash/build/cfe_plugin/test_results/cfe_plugin/test_telemetry_flow.xunit.xml'
1/1 Test #1: test_telemetry_flow ..............   Passed    2.32 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
pytest    =   2.32 sec*proc (1 test)

Total Test time (real) =   2.32 sec
```