### PR TITLE
Add test that verifies CFE Set MET command works.

### DIFF
--- a/cfe_plugin/CMakeLists.txt
+++ b/cfe_plugin/CMakeLists.txt
@@ -45,6 +45,9 @@ if(BUILD_TESTING)
   ament_add_pytest_test(
     test_telemetry_flow test/test_telemetry_flow.py
     TIMEOUT 90)
-endif()
+  ament_add_pytest_test(
+    test_cfe_set_time test/test_cfe_set_time.py
+    TIMEOUT 90)
+  endif()
 
 ament_package()

--- a/cfe_plugin/test/test_cfe_set_time.py
+++ b/cfe_plugin/test/test_cfe_set_time.py
@@ -84,12 +84,18 @@ class TestTelemetryFlow(unittest.TestCase):
    def test_flow(self):
       subscriber = ParticipantNode()
 
+      time.sleep(3)
+
       # Send the Set STCF (Spacecraft Time Correlation Factor) function.  This ensures that the Spacecraft Time is identical to the MET.
       subscriber.publish_set_stcf_cmd(0)
+
+      time.sleep(3)
 
       # Send the Set MET command.
       time_seconds = 200000
       subscriber.publish_set_met_cmd(time_seconds)
+
+      time.sleep(3)
 
       # Spin for a few messages to ensure we see fresh messages.
       for i in range(10):

--- a/cfe_plugin/test/test_cfe_set_time.py
+++ b/cfe_plugin/test/test_cfe_set_time.py
@@ -84,21 +84,16 @@ class TestTelemetryFlow(unittest.TestCase):
    def test_flow(self):
       subscriber = ParticipantNode()
 
-      time.sleep(3)
-
       # Send the Set STCF (Spacecraft Time Correlation Factor) function.  This ensures that the Spacecraft Time is identical to the MET.
       subscriber.publish_set_stcf_cmd(0)
-
-      time.sleep(3)
 
       # Send the Set MET command.
       time_seconds = 200000
       subscriber.publish_set_met_cmd(time_seconds)
 
-      time.sleep(3)
-
-      # Wait for a message response.
-      rclpy.spin_once(subscriber, timeout_sec=30)
+      # Spin for a few messages to ensure we see fresh messages.
+      for i in range(10):
+         rclpy.spin_once(subscriber, timeout_sec=30)
 
       # Assert that we've heard a message and that the time in the secondary header corresponds to the new MET value.
       self.assertGreater(subscriber.get_messages_heard(), 0)

--- a/cfe_plugin/test/test_cfe_set_time.py
+++ b/cfe_plugin/test/test_cfe_set_time.py
@@ -1,0 +1,92 @@
+import unittest
+import struct
+import time
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+
+from cfe_msgs.msg import CFEESHousekeepingTlm
+from cfe_msgs.msg import CFETIMETimeCmd
+
+# https://stackoverflow.com/a/27506692
+def swap32(i):
+    return struct.unpack("<I", struct.pack(">I", i))[0]
+
+class ParticipantNode(Node):
+   def __init__(self):
+      super().__init__('cfe_time_test_subscriber')
+
+      # Create a subscriber that allows us to receive ES housekeeping telemetry
+      self.subscription = self.create_subscription(
+         CFEESHousekeepingTlm,
+         '/groundsystem/cfe_es_hk_tlm',
+         self.listener_callback,
+         10)
+      self.subscription  # prevent unused variable warning
+      self.num_messages_received = 0
+      self.last_cfe_met_sec_received = 0
+
+      # Create a publisher so that we can send the SET MET command
+      self.publisher = self.create_publisher(
+         CFETIMETimeCmd,
+         '/groundsystem/cfe_time_set_met_cmd',
+         10)
+
+   # Function that sends a CFE Set MET command using time_seconds as the desired seconds value.
+   def publish_set_met_cmd(self, time_seconds):
+      msg = CFETIMETimeCmd()
+      msg.payload.seconds = swap32(time_seconds)
+      msg.payload.micro_seconds = 0
+      self.publisher.publish(msg)
+
+   def listener_callback(self, msg):
+      # Record that a message was seen.
+      self.num_messages_received += 1
+
+      # Extract time from ES housekeeping packet secondary header.
+      (met_seconds, met_subseconds) = struct.unpack(">IH", msg.telemetry_header.sec.time)
+      self.last_cfe_met_sec_received = met_seconds
+
+      # Generate a log message
+      self.get_logger().info('I heard something with met %d' % met_seconds)
+
+   def get_messages_heard(self):
+      return self.num_messages_received
+   
+   def get_last_cfe_met_sec_received(self):
+      return self.last_cfe_met_sec_received
+
+class TestTelemetryFlow(unittest.TestCase):
+   @classmethod
+   def setUpClass(cls):
+      # Initialize the ROS context for the test node
+      rclpy.init()
+
+   @classmethod
+   def tearDownClass(cls):
+      # Shutdown the ROS context
+      rclpy.shutdown()
+
+   def test_flow(self):
+      subscriber = ParticipantNode()
+
+      time.sleep(3)
+
+      # Send the Set MET command.
+      time_seconds = 200000
+      subscriber.publish_set_met_cmd(time_seconds)
+
+      time.sleep(3)
+
+      # Wait for a message response.
+      rclpy.spin_once(subscriber, timeout_sec=30)
+
+      # Assert that we've heard a message and that the time in the secondary header corresponds to the new MET value.
+      self.assertTrue(subscriber.get_messages_heard() > 0, "Didn't receive any subscribed messages.")
+      self.assertTrue(subscriber.get_last_cfe_met_sec_received() >= time_seconds, "Time didn't change as expected.")
+
+      subscriber.destroy_node()
+
+if __name__ == '__main__':
+   unittest.main()


### PR DESCRIPTION
The test is run as part of the cfe_plugin colcon test suite and will be run as the second test using the following command:
```
colcon test  --event-handlers console_cohesion+ --ctest-args " -VVV" --return-code-on-test-failure --packages-select cfe_plugin
```

This test ensures that the CFE Set MET command works as expected.   If run, this is the expected output:
```
    Start 2: test_cfe_set_time

2: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/code/brash/build/cfe_plugin/test_results/cfe_plugin/test_cfe_set_time.xunit.xml" "--package-name" "cfe_plugin" "--output-file" "/code/brash/build/cfe_plugin/ament_cmake_pytest/test_cfe_set_time.txt" "--command" "/usr/bin/python3" "-u" "-m" "pytest" "/code/brash/src/cfe_ros2_bridge_plugin/cfe_plugin/test/test_cfe_set_time.py" "-o" "cache_dir=/code/brash/build/cfe_plugin/ament_cmake_pytest/test_cfe_set_time/.cache" "--junit-xml=/code/brash/build/cfe_plugin/test_results/cfe_plugin/test_cfe_set_time.xunit.xml" "--junit-prefix=cfe_plugin"
2: Test timeout computed to be: 90
2: -- run_test.py: invoking following command in '/code/brash/build/cfe_plugin':
2:  - /usr/bin/python3 -u -m pytest /code/brash/src/cfe_ros2_bridge_plugin/cfe_plugin/test/test_cfe_set_time.py -o cache_dir=/code/brash/build/cfe_plugin/ament_cmake_pytest/test_cfe_set_time/.cache --junit-xml=/code/brash/build/cfe_plugin/test_results/cfe_plugin/test_cfe_set_time.xunit.xml --junit-prefix=cfe_plugin
2: ============================= test session starts ==============================
2: platform linux -- Python 3.10.12, pytest-6.2.5, py-1.10.0, pluggy-0.13.0
2: cachedir: /code/brash/build/cfe_plugin/ament_cmake_pytest/test_cfe_set_time/.cache
2: rootdir: /code/brash/src/cfe_ros2_bridge_plugin/cfe_plugin, configfile: pytest.ini
2: plugins: launch-testing-ros-0.19.7, ament-xmllint-0.12.10, ament-copyright-0.12.10, ament-lint-0.12.10, ament-pep257-0.12.10, ament-flake8-0.12.10, launch-testing-1.0.5, colcon-core-0.15.2
2: collected 1 item
2: 
2: ../../src/cfe_ros2_bridge_plugin/cfe_plugin/test/test_cfe_set_time.py .  [100%]
2: 
2: - generated xml file: /code/brash/build/cfe_plugin/test_results/cfe_plugin/test_cfe_set_time.xunit.xml -
2: ============================== 1 passed in 6.38s ===============================
2: -- run_test.py: return code 0
2: -- run_test.py: verify result file '/code/brash/build/cfe_plugin/test_results/cfe_plugin/test_cfe_set_time.xunit.xml'
2/2 Test #2: test_cfe_set_time ................   Passed    7.12 sec

```

Additionally, on the CFE side, the test sets the MET to 200000 seconds, so messages should show up that look something like this:
```
fsw-1  | EVS Port1 66/2/ROS_APP 8: ros: Hello, ros! v1.2.0-rc1+dev48.  Time is 1027 sec and 2966750807 subsec
fsw-1  | RobotSimReportHousekeeping reporting: 26
fsw-1  | RoverAppReportHousekeeping reporting: 26
fsw-1  | EVS Port1 66/2/CFE_TIME 13: Set MET -- secs = 200000, usecs = 0, ssecs = 0x0
fsw-1  | RoverAppReportHousekeeping reporting: 27
fsw-1  | RobotSimReportHousekeeping reporting: 27
fsw-1  | EVS Port1 66/2/ROS_APP 8: ros: Hello, ros! v1.2.0-rc1+dev48.  Time is 200000 sec and 2151875252 subsec
fsw-1  | RobotSimReportHousekeeping reporting: 28
fsw-1  | EVS Port1 66/2/ROS_APP 8: ros: Hello, ros! v1.2.0-rc1+dev48.  Time is 200001 sec and 2966695402 subsec
fsw-1  | RoverAppReportHousekeeping reporting: 28
fsw-1  | EVS Port1 66/2/ROS_APP 8: ros: Hello, ros! v1.2.0-rc1+dev48.  Time is 200002 sec and 2963956072 subsec
```