### PR TITLE
Bugfix/cfdp bridge mappings

### DIFF
--- a/juicer_util/config/cfe_plugin_config.yaml
+++ b/juicer_util/config/cfe_plugin_config.yaml
@@ -12,7 +12,7 @@
           cmd_code: 0
         CfdpCh2Uplink:
           cfe_mid: '0x18ca'
-          topic_name: /sbn/cfdp/pdu
+          topic_name: /flightsystem/cfdp/pdu
           cmd_code: 0
         CPU1CFEESStopAppCmd:
           structure: CFEESAppNameCmd
@@ -593,10 +593,10 @@
           topic_name: cfdp_hk_tlm
         CfdpCh0Dlink:
           cfe_mid: '0x8c2'
-          topic_name: /cfdp/pdu
+          topic_name: /groundsystem/cfdp/pdu
         CfdpCh2Dlink:
           cfe_mid: '0x8c4'
-          topic_name: /cfdp/pdu
+          topic_name: /cfe/cfdp/pdu
         RoverAppHkTlm:
           structure: RoverAppHkTlmt
           cfe_mid: '0x826'

--- a/juicer_util/config/cfe_plugin_config.yaml
+++ b/juicer_util/config/cfe_plugin_config.yaml
@@ -3,8 +3,8 @@
     plugin_params:
       juicer_db: ["cfs_bootes-rc1-dev83_TL.sqlite"]
       map_ros_name: ["src/cfe_ros2_bridge_plugin/cfe_msg_converter/config/map_ros_name.yaml"]
-      commands: ["CPU1CFEESStopAppCmd", "CPU1CFEESRestartAppCmd", "CPU1CFEESQueryOneCmd", "CPU1CFEESDeleteCDSCmd", "CPU1CFEESDumpCDSRegistryCmd", "CPU1CFEESQueryAllCmd", "CPU1CFEESQueryAllTasksCmd", "CPU1CFEESWriteSysLogCmd", "CPU1CFEESWriteERLogCmd", "CPU1CFEESNoopCmd", "CPU1CFEESResetCountersCmd", "CPU1CFEESClearSysLogCmd", "CPU1CFEESClearERLogCmd", "CPU1CFEESResetPRCountCmd", "CPU1CFEESOverWriteSysLogCmd", "CPU1CFEESReloadAppCmd", "CPU1CFEESRestartCmd", "CPU1CFEESSendMemPoolStatsCmd", "CPU1CFEESSetMaxPRCountCmd", "CPU1CFEESSetPerfFilterMaskCmd", "CPU1CFEESSetPerfTriggerMaskCmd", "CPU1CFEESStartApp", "CPU1CFEESStartPerfDataCmd", "CPU1CFEESStopPerfDataCmd", "CPU1CFEEVSEnableAppEventTypeCmd", "CPU1CFEEVSDisableAppEventTypeCmd", "CPU1CFEEVSEnableAppEventsCmd", "CPU1CFEEVSDisableAppEventsCmd", "CPU1CFEEVSResetAppCounterCmd", "CPU1CFEEVSResetAllFiltersCmd", "CPU1CFEEVSResetFilterCmd", "CPU1CFEEVSDeleteEventFilterCmd", "CPU1CFEEVSAddEventFilterCmd", "CPU1CFEEVSSetFilterCmd", "CPU1CFEEVSEnablePortsCmd", "CPU1CFEEVSDisablePortsCmd", "CPU1CFEEVSEnableEventTypeCmd", "CPU1CFEEVSDisableEventTypeCmd", "CPU1CFEEVSNoopCmd", "CPU1CFEEVSResetCountersCmd", "CPU1CFEEVSClearLogCmd", "CPU1CFEEVSSetEventFormatModeCmd", "CPU1CFEEVSSetLogModeCmd", "CPU1CFEEVSWriteAppDataFileCmd", "CPU1CFEEVSWriteLogDataFileCmd", "CPU1CFESBEnableRouteCmd", "CPU1CFESBDisableRouteCmd", "CPU1CFESBNoopCmd", "CPU1CFESBResetCountersCmd", "CPU1CFESBEnableSubReportingCmd", "CPU1CFESBDisableSubReportingCmd", "CPU1CFESBSendSbStatsCmd", "CPU1CFESBSendPrevSubsCmd", "CPU1CFESBWriteRoutingInfoCmd", "CPU1CFESBWritePipeInfoCmd", "CPU1CFESBWriteMapInfoCmd", "CPU1CFETBLAbortLoadCmd", "CPU1CFETBLActivateCmd", "CPU1CFETBLDeleteCDSCmd", "CPU1CFETBLDumpCmd", "CPU1CFETBLDumpRegistryCmd", "CPU1CFETBLLoadCmd", "CPU1CFETBLNoopCmd", "CPU1CFETBLResetCountersCmd", "CPU1CFETBLSendRegistryCmd", "CPU1CFETBLValidateCmd", "CPU1CFETIMENoopCmd", "CPU1CFETIMEResetCountersCmd", "CPU1CFETIMESendDiagnosticCmd", "CPU1CFETIMEAdd1HZAdjustmentCmd", "CPU1CFETIMESub1HZAdjustmentCmd", "CPU1CFETIMESetLeapSecondsCmd", "CPU1CFETIMESetSignalCmd", "CPU1CFETIMESetSourceCmd", "CPU1CFETIMESetStateCmd", "CPU1CFETIMEAddDelayCmd", "CPU1CFETIMESubDelayCmd", "CPU1CFETIMESetMETCmd", "CPU1CFETIMESetSTCFCmd", "CPU1CFETIMEAddAdjustCmd", "CPU1CFETIMESubAdjustCmd", "CPU1CFETIMESetTimeCmd", "CPU1CILABNoArgsCmd", "CPU1ROSAPPNoArgsCmd", "CPU1SCHLABStateEntry", "CPU1TOLABAddPacketCmd", "CPU1TOLABEnableOutputCmd", "CPU1TOLABNoopCmd", "CPU1TOLABResetCountersCmd", "CPU1TOLABRemoveAllCmd", "CPU1TOLABSendDataTypesCmd", "CPU1TOLABRemovePacketCmd", "CPU1RobotSimJointCmdt", "CfdpCh0Uplink", "CfdpCh2Uplink", "RoverAppTwistCmd", "RoverAppReceiveRobotState"]      
-      telemetry: ["CPU1CFEESOneAppTlm", "CPU1CFEESMemStatsTlm", "CPU1CFEESHousekeepingTlm", "CPU1CFEEVSLongEventTlm", "CPU1CFEEVSHousekeepingTlm", "CPU1CFEEVSShortEventTlm", "CPU1CFESBHousekeepingTlm", "CPU1CFESBStatsTlm", "CPU1CFESBAllSubscriptionsTlm", "CPU1CFESBSingleSubscriptionTlm", "CPU1CFETBLHousekeepingTlm", "CPU1CFETBLTableRegistryTlm", "CPU1CFETIMEHousekeepingTlm", "CPU1CFETIMEDiagnosticTlm", "CPU1CILABHkTlm", "CPU1TOLABHkTlm", "CPU1TOLABDataTypesTlm", "CPU1ROSAPPRosoutInfoTlmt", "CPU1ROSAPPRosoutWarnTlmt", "CPU1ROSAPPRosoutErrorTlmt", "CPU1ROSAPPRosoutDebugTlmt", "CPU1ROSAPPRosoutFatalTlmt", "CPU1RobotSimHkTlmt", "CPU1RobotSimStateTlmt", "CfdpCh0Dlink", "CfdpCh2Dlink", "CfdpHkTlm", "RoverAppHkTlm", "RoverAppSendRobotCommand"]
+      commands: ["CPU1CFEESStopAppCmd", "CPU1CFEESRestartAppCmd", "CPU1CFEESQueryOneCmd", "CPU1CFEESDeleteCDSCmd", "CPU1CFEESDumpCDSRegistryCmd", "CPU1CFEESQueryAllCmd", "CPU1CFEESQueryAllTasksCmd", "CPU1CFEESWriteSysLogCmd", "CPU1CFEESWriteERLogCmd", "CPU1CFEESNoopCmd", "CPU1CFEESResetCountersCmd", "CPU1CFEESClearSysLogCmd", "CPU1CFEESClearERLogCmd", "CPU1CFEESResetPRCountCmd", "CPU1CFEESOverWriteSysLogCmd", "CPU1CFEESReloadAppCmd", "CPU1CFEESRestartCmd", "CPU1CFEESSendMemPoolStatsCmd", "CPU1CFEESSetMaxPRCountCmd", "CPU1CFEESSetPerfFilterMaskCmd", "CPU1CFEESSetPerfTriggerMaskCmd", "CPU1CFEESStartApp", "CPU1CFEESStartPerfDataCmd", "CPU1CFEESStopPerfDataCmd", "CPU1CFEEVSEnableAppEventTypeCmd", "CPU1CFEEVSDisableAppEventTypeCmd", "CPU1CFEEVSEnableAppEventsCmd", "CPU1CFEEVSDisableAppEventsCmd", "CPU1CFEEVSResetAppCounterCmd", "CPU1CFEEVSResetAllFiltersCmd", "CPU1CFEEVSResetFilterCmd", "CPU1CFEEVSDeleteEventFilterCmd", "CPU1CFEEVSAddEventFilterCmd", "CPU1CFEEVSSetFilterCmd", "CPU1CFEEVSEnablePortsCmd", "CPU1CFEEVSDisablePortsCmd", "CPU1CFEEVSEnableEventTypeCmd", "CPU1CFEEVSDisableEventTypeCmd", "CPU1CFEEVSNoopCmd", "CPU1CFEEVSResetCountersCmd", "CPU1CFEEVSClearLogCmd", "CPU1CFEEVSSetEventFormatModeCmd", "CPU1CFEEVSSetLogModeCmd", "CPU1CFEEVSWriteAppDataFileCmd", "CPU1CFEEVSWriteLogDataFileCmd", "CPU1CFESBEnableRouteCmd", "CPU1CFESBDisableRouteCmd", "CPU1CFESBNoopCmd", "CPU1CFESBResetCountersCmd", "CPU1CFESBEnableSubReportingCmd", "CPU1CFESBDisableSubReportingCmd", "CPU1CFESBSendSbStatsCmd", "CPU1CFESBSendPrevSubsCmd", "CPU1CFESBWriteRoutingInfoCmd", "CPU1CFESBWritePipeInfoCmd", "CPU1CFESBWriteMapInfoCmd", "CPU1CFETBLAbortLoadCmd", "CPU1CFETBLActivateCmd", "CPU1CFETBLDeleteCDSCmd", "CPU1CFETBLDumpCmd", "CPU1CFETBLDumpRegistryCmd", "CPU1CFETBLLoadCmd", "CPU1CFETBLNoopCmd", "CPU1CFETBLResetCountersCmd", "CPU1CFETBLSendRegistryCmd", "CPU1CFETBLValidateCmd", "CPU1CFETIMENoopCmd", "CPU1CFETIMEResetCountersCmd", "CPU1CFETIMESendDiagnosticCmd", "CPU1CFETIMEAdd1HZAdjustmentCmd", "CPU1CFETIMESub1HZAdjustmentCmd", "CPU1CFETIMESetLeapSecondsCmd", "CPU1CFETIMESetSignalCmd", "CPU1CFETIMESetSourceCmd", "CPU1CFETIMESetStateCmd", "CPU1CFETIMEAddDelayCmd", "CPU1CFETIMESubDelayCmd", "CPU1CFETIMESetMETCmd", "CPU1CFETIMESetSTCFCmd", "CPU1CFETIMEAddAdjustCmd", "CPU1CFETIMESubAdjustCmd", "CPU1CFETIMESetTimeCmd", "CPU1CILABNoArgsCmd", "CPU1ROSAPPNoArgsCmd", "CPU1SCHLABStateEntry", "CPU1TOLABAddPacketCmd", "CPU1TOLABEnableOutputCmd", "CPU1TOLABNoopCmd", "CPU1TOLABResetCountersCmd", "CPU1TOLABRemoveAllCmd", "CPU1TOLABSendDataTypesCmd", "CPU1TOLABRemovePacketCmd", "CPU1RobotSimJointCmdt", "CfdpCh0Uplink", "CfdpCh2Uplink", "CfdpCh2Dlink", "RoverAppTwistCmd", "RoverAppReceiveRobotState"]      
+      telemetry: ["CPU1CFEESOneAppTlm", "CPU1CFEESMemStatsTlm", "CPU1CFEESHousekeepingTlm", "CPU1CFEEVSLongEventTlm", "CPU1CFEEVSHousekeepingTlm", "CPU1CFEEVSShortEventTlm", "CPU1CFESBHousekeepingTlm", "CPU1CFESBStatsTlm", "CPU1CFESBAllSubscriptionsTlm", "CPU1CFESBSingleSubscriptionTlm", "CPU1CFETBLHousekeepingTlm", "CPU1CFETBLTableRegistryTlm", "CPU1CFETIMEHousekeepingTlm", "CPU1CFETIMEDiagnosticTlm", "CPU1CILABHkTlm", "CPU1TOLABHkTlm", "CPU1TOLABDataTypesTlm", "CPU1ROSAPPRosoutInfoTlmt", "CPU1ROSAPPRosoutWarnTlmt", "CPU1ROSAPPRosoutErrorTlmt", "CPU1ROSAPPRosoutDebugTlmt", "CPU1ROSAPPRosoutFatalTlmt", "CPU1RobotSimHkTlmt", "CPU1RobotSimStateTlmt", "CfdpCh0Dlink", "CfdpCh1Dlink", "CfdpCh2Uplink","CfdpCh2Dlink", "CfdpHkTlm", "RoverAppHkTlm", "RoverAppSendRobotCommand"]
       command_data:
         CfdpCh0Uplink:
           cfe_mid: '0x18c8'
@@ -14,6 +14,19 @@
           cfe_mid: '0x18ca'
           topic_name: /flightsystem/cfdp/pdu
           cmd_code: 0
+        CfdpCh2Dlink:
+          cfe_mid: '0x8c4'
+          topic_name: /groundsystem/cfdp/pdu
+        CfdpNopCmd:
+          structure: CF_NoArgsCmd_t
+          cfe_mid: '0x18b3'
+          cmd_code: 0
+          topic_name: cfdp_noop_cmd
+        CfdpTXCmd:
+          structure: CF_TxFileCmd
+          cfe_mid: '0x18b3'
+          cmd_code: 2
+          topic_name: cfdp_tx_cmd
         CPU1CFEESStopAppCmd:
           structure: CFEESAppNameCmd
           cfe_mid: '0x1806'
@@ -594,9 +607,17 @@
         CfdpCh0Dlink:
           cfe_mid: '0x8c2'
           topic_name: /groundsystem/cfdp/pdu
+        CfdpCh1Dlink:
+          cfe_mid: '0x8c3'
+          topic_name: /flightsystem/cfdp/pdu
+          cmd_code: 0
         CfdpCh2Dlink:
           cfe_mid: '0x8c4'
-          topic_name: /cfe/cfdp/pdu
+          topic_name: /groundsystem/cfdp/pdu
+        CfdpCh2Uplink:
+          cfe_mid: '0x18ca'
+          topic_name: /flightsystem/cfdp/pdu
+          cmd_code: 0
         RoverAppHkTlm:
           structure: RoverAppHkTlmt
           cfe_mid: '0x826'


### PR DESCRIPTION
Test case: Docker demo of RoboSim; trying to run the instructions on: https://traclabs-brash.bitbucket.io/brash_file_transfer.html

Before this PR: I wasn't able to run the first service example:
```
$ ros2 service call /groundsystem/cfdp/cmd/ls cfdp_msgs/srv/CfdpXfrCmd "{src: '', dst: 'dst1_dirlisting.txt', dstid: 2}"
```
meaning: dst1_dirlisting.txt was not created (in cfdp/rosgsw). 

After  this PR: The service call correctly creates dst1_dirlisting.txt and fills it with the files in cfdp/rosfsw in the flightsystem side.

Have yet to test the remaining services, but on this fix alone, merging this PR.
